### PR TITLE
jim - environment variables can be secure but unencrypted

### DIFF
--- a/gomatic/go_cd_configurator_test.py
+++ b/gomatic/go_cd_configurator_test.py
@@ -809,15 +809,24 @@ class TestPipeline(unittest.TestCase):
         pipeline = GoCdConfigurator(config('config-with-encrypted-variable')).ensure_pipeline_group("defaultGroup").find_pipeline("example")
         self.assertEquals({"MY_SECURE_PASSWORD": "yq5qqPrrD9/htfwTWMYqGQ=="}, pipeline.encrypted_environment_variables())
 
+    def test_pipelines_have_unencrypted_secure_environment_variables(self):
+        pipeline = GoCdConfigurator(config('config-with-unencrypted-secure-variable')).ensure_pipeline_group("defaultGroup").find_pipeline("example")
+        self.assertEquals({"MY_SECURE_PASSWORD": "hunter2"}, pipeline.unencrypted_secure_environment_variables())
+
     def test_can_add_environment_variables_to_pipeline(self):
         pipeline = empty_pipeline()
         pipeline.ensure_environment_variables({"new": "one", "again": "two"})
         self.assertEquals({"new": "one", "again": "two"}, pipeline.environment_variables())
 
-    def test_can_add_encrypted_environment_variables_to_pipeline(self):
+    def test_can_add_encrypted_secure_environment_variables_to_pipeline(self):
         pipeline = empty_pipeline()
         pipeline.ensure_encrypted_environment_variables({"new": "one", "again": "two"})
         self.assertEquals({"new": "one", "again": "two"}, pipeline.encrypted_environment_variables())
+
+    def test_can_add_unencrypted_secure_environment_variables_to_pipeline(self):
+        pipeline = empty_pipeline()
+        pipeline.ensure_unencrypted_secure_environment_variables({"new": "one", "again": "two"})
+        self.assertEquals({"new": "one", "again": "two"}, pipeline.unencrypted_secure_environment_variables())
 
     def test_can_add_environment_variables_to_new_pipeline(self):
         pipeline = typical_pipeline()

--- a/gomatic/test-data/config-with-unencrypted-secure-variable.xml
+++ b/gomatic/test-data/config-with-unencrypted-secure-variable.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<cruise xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="cruise-config.xsd" schemaVersion="72">
+    <server artifactsdir="artifacts" commandRepositoryLocation="default" serverId="779d5885-3db5-4640-8901-f9333bc10046" />
+    <pipelines group="defaultGroup">
+        <pipeline name="example">
+            <environmentvariables>
+                <variable name="MY_SECURE_PASSWORD" secure="true">
+                    <value>hunter2</value>
+                </variable>
+            </environmentvariables>
+            <materials>
+                <git url="gitUrl" />
+            </materials>
+            <stage name="defaultStage">
+                <jobs>
+                    <job name="defaultJob">
+                        <tasks>
+                            <exec command="ls" />
+                        </tasks>
+                    </job>
+                </jobs>
+            </stage>
+        </pipeline>
+    </pipelines>
+</cruise>


### PR DESCRIPTION
Hello!

GoCD allows you to add 'secure' environment variables to a config in clear text - it will encrypt them when it loads the config. This commit adds support for such things. It is quite ugly, and I think it would be better if 'ensure_encrypted_environment_variables' et al were renamed 'ensure_secure_environment_variables', with encryption being an option, but that would be a breaking change. Anyway, happy to talk through the details, long time no see, etc. 

PS I haven't run the integration tests yet because they don't appear to run as-is on OSX.